### PR TITLE
Implement order matching and book display

### DIFF
--- a/src/LimitOrderBook.cpp
+++ b/src/LimitOrderBook.cpp
@@ -1,4 +1,4 @@
-#include <string>
+#include <iostream>
 using namespace std;
 
 class Node {
@@ -264,12 +264,54 @@ public:
   double getBestBid() {
     Node *n = bids.maximum();
 
-    return n ? n->price : -1;
+    return (n == nullptr || n->price == 0) ? -1 : n->price;
   }
 
   double getBestAsk() {
     Node *n = asks.minimum();
 
-    return n ? n->price : -1;
+    return (n == nullptr || n->price == 0) ? -1 : n->price;
+  }
+
+  void matchOrders() {
+    Node *bestBid = bids.maximum();
+    Node *bestAsk = asks.minimum();
+
+    while (bestBid && bestAsk && bestBid->price >= bestAsk->price) {
+      int tradedQty = min(bestBid->quantity, bestAsk->quantity);
+
+      cout << "TRADE: " << tradedQty << " @ " << bestAsk->price << "\n";
+
+      bestBid->quantity -= tradedQty;
+      bestAsk->quantity -= tradedQty;
+
+      if (bestBid->quantity == 0) {
+        bestBid = bids.predecessor(bestBid);
+      }
+
+      if (bestAsk->quantity == 0) {
+        bestAsk = asks.successor(bestAsk);
+      }
+    }
+  }
+
+  void displayBook(int depth = 5) {
+    cout << "---- BIDS ----\n";
+
+    Node *b = bids.maximum();
+
+    for (int i = 0; b && i < depth; i++) {
+      cout << b->price << " : " << b->quantity << "\n";
+      b = bids.predecessor(b);
+    }
+
+    cout << "---- ASKS ----\n";
+
+    Node *a = asks.minimum();
+
+    for (int i = 0; a && i < depth; i++) {
+      cout << a->price << " : " << a->quantity << "\n";
+      a = asks.successor(a);
+    }
   }
 };


### PR DESCRIPTION
**Description:**
This PR adds core matching and visualisation functionality to the LimitOrderBook.

**Key details:**
* `matchOrders()`:
  * Matches the best bid and ask when bid price >= ask price.
  * Executes trades by reducing quantities from both sides.
  * Logs trade details (`TRADE: qty @ price`) to the console.
  * Updates best bid/ask iteratively until no match is possible.
* `displayBook(depth)`:
  * Prints the top levels of the order book up to a given depth.
  * Shows bids in descending order and asks in ascending order.
  * Provides a simple way to visualise book state during testing.